### PR TITLE
Include Dashboard CRDs in OLM bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ MANIFESTS_TARBALL_URL="https://github.com/${MANIFEST_REPO}/odh-manifests/tarball
 
 .PHONY: get-manifests
 get-manifests: ## Get latest odh-manifests tarball
-	rm -r odh-manifests && mkdir odh-manifests
+	rm -fr odh-manifests && mkdir odh-manifests
 	wget -c $(MANIFESTS_TARBALL_URL) -O - | tar -xv -C odh-manifests/ --strip-components 1
 
 ##@ Deployment

--- a/Makefile
+++ b/Makefile
@@ -251,3 +251,17 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+TOOLBOX_GOLANG_VERSION := 1.18.9
+TOOLBOX_OPERATOR_SDK_VERSION := 1.24.1
+
+# Generate a Toolbox container for locally testing changes easily
+.PHONY: toolbox
+toolbox: ## Create a toolbox instance with the proper Golang and Operator SDK versions
+	$(IMAGE_BUILDER) build \
+		--build-arg GOLANG_VERSION=$(TOOLBOX_GOLANG_VERSION) \
+		--build-arg OPERATOR_SDK_VERSION=$(TOOLBOX_OPERATOR_SDK_VERSION) \
+		-f toolbox.Dockerfile -t opendatahub-toolbox .
+	$(IMAGE_BUILDER) stop opendatahub-toolbox ||:
+	toolbox rm opendatahub-toolbox ||:
+	toolbox create opendatahub-toolbox --image localhost/opendatahub-toolbox:latest

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: test odh-manifests/version.py ## Build docker image with the manager.
 	${IMAGE_BUILDER} build -t ${IMG} .
 
 .PHONY: docker-push
@@ -137,7 +137,9 @@ image: docker-build docker-push ## Build and push docker image with the manager.
 MANIFESTS_TARBALL_URL="https://github.com/${MANIFEST_REPO}/odh-manifests/tarball/${MANIFEST_RELEASE}"
 
 .PHONY: get-manifests
-get-manifests: ## Get latest odh-manifests tarball
+get-manifests: odh-manifests/version.py ## Get latest odh-manifests tarball
+
+odh-manifests/version.py: ## Get latest odh-manifests tarball
 	rm -fr odh-manifests && mkdir odh-manifests
 	wget -c $(MANIFESTS_TARBALL_URL) -O - | tar -zxv -C odh-manifests/ --strip-components 1
 

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ MANIFESTS_TARBALL_URL="https://github.com/${MANIFEST_REPO}/odh-manifests/tarball
 .PHONY: get-manifests
 get-manifests: ## Get latest odh-manifests tarball
 	rm -fr odh-manifests && mkdir odh-manifests
-	wget -c $(MANIFESTS_TARBALL_URL) -O - | tar -xv -C odh-manifests/ --strip-components 1
+	wget -c $(MANIFESTS_TARBALL_URL) -O - | tar -zxv -C odh-manifests/ --strip-components 1
 
 ##@ Deployment
 

--- a/bundle/manifests/console.openshift.io_odhquickstarts.yaml
+++ b/bundle/manifests/console.openshift.io_odhquickstarts.yaml
@@ -1,0 +1,216 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    description: Extension for guiding user through various workflows in the Red Hat
+      OpenShift Data Science dashboard.
+    displayName: OdhQuickStart
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  creationTimestamp: null
+  labels:
+    opendatahub.io/dashboardcrd: "true"
+  name: odhquickstarts.console.openshift.io
+spec:
+  group: console.openshift.io
+  names:
+    kind: OdhQuickStart
+    listKind: OdhQuickStartList
+    plural: odhquickstarts
+    singular: odhquickstart
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OdhQuickStart is an extension for guiding user through various
+          workflows in the Red Hat OpenShift Data Science dashboard.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OdhQuickStartSpec is the desired quick start configuration.
+            properties:
+              accessReviewResources:
+                description: accessReviewResources contains a list of resources that
+                  the user's access will be reviewed against in order for the user
+                  to complete the Quick Start. The Quick Start will be hidden if any
+                  of the access reviews fail.
+                items:
+                  description: ResourceAttributes includes the authorization attributes
+                    available for resource requests to the Authorizer interface
+                  properties:
+                    group:
+                      description: Group is the API Group of the Resource.  "*" means
+                        all.
+                      type: string
+                    name:
+                      description: Name is the name of the resource being requested
+                        for a "get" or deleted for a "delete". "" (empty) means all.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the action being
+                        requested.  Currently, there is no distinction between no
+                        namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews
+                        "" (empty) is empty for cluster-scoped resources "" (empty)
+                        means "all" for namespace scoped resources from a SubjectAccessReview
+                        or SelfSubjectAccessReview
+                      type: string
+                    resource:
+                      description: Resource is one of the existing resource types.  "*"
+                        means all.
+                      type: string
+                    subresource:
+                      description: Subresource is one of the existing resource types.  ""
+                        means none.
+                      type: string
+                    verb:
+                      description: 'Verb is a kubernetes resource API verb, like:
+                        get, list, watch, create, update, delete, proxy.  "*" means
+                        all.'
+                      type: string
+                    version:
+                      description: Version is the API Version of the Resource.  "*"
+                        means all.
+                      type: string
+                  type: object
+                type: array
+              appName:
+                description: the name/id of the odh application the quick start pertains
+                  to
+                type: string
+              conclusion:
+                description: conclusion sums up the Quick Start and suggests the possible
+                  next steps. (includes markdown)
+                type: string
+              description:
+                description: description is the description of the Quick Start. (includes
+                  markdown)
+                maxLength: 256
+                minLength: 1
+                type: string
+              displayName:
+                description: displayName is the display name of the Quick Start.
+                minLength: 1
+                type: string
+              durationMinutes:
+                description: durationMinutes describes approximately how many minutes
+                  it will take to complete the Quick Start.
+                minimum: 1
+                type: integer
+              icon:
+                description: icon is a base64 encoded image that will be displayed
+                  beside the Quick Start display name. The icon should be an vector
+                  image for easy scaling. The size of the icon should be 40x40.
+                type: string
+              introduction:
+                description: introduction describes the purpose of the Quick Start.
+                  (includes markdown)
+                minLength: 1
+                type: string
+              nextQuickStart:
+                description: nextQuickStart is a list of the following Quick Starts,
+                  suggested for the user to try.
+                items:
+                  type: string
+                type: array
+              prerequisites:
+                description: prerequisites contains all prerequisites that need to
+                  be met before taking a Quick Start. (includes markdown)
+                items:
+                  type: string
+                type: array
+              tags:
+                description: tags is a list of strings that describe the Quick Start.
+                items:
+                  type: string
+                type: array
+              tasks:
+                description: tasks is the list of steps the user has to perform to
+                  complete the Quick Start.
+                items:
+                  description: OdhQuickStartTask is a single step in a Quick Start.
+                  properties:
+                    description:
+                      description: description describes the steps needed to complete
+                        the task. (includes markdown)
+                      minLength: 1
+                      type: string
+                    review:
+                      description: review contains instructions to validate the task
+                        is complete. The user will select 'Yes' or 'No'. using a radio
+                        button, which indicates whether the step was completed successfully.
+                      properties:
+                        failedTaskHelp:
+                          description: failedTaskHelp contains suggestions for a failed
+                            task review and is shown at the end of task. (includes
+                            markdown)
+                          minLength: 1
+                          type: string
+                        instructions:
+                          description: instructions contains steps that user needs
+                            to take in order to validate his work after going through
+                            a task. (includes markdown)
+                          minLength: 1
+                          type: string
+                      required:
+                      - failedTaskHelp
+                      - instructions
+                      type: object
+                    summary:
+                      description: summary contains information about the passed step.
+                      properties:
+                        failed:
+                          description: failed briefly describes the unsuccessfully
+                            passed task. (includes markdown)
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        success:
+                          description: success describes the succesfully passed task.
+                          minLength: 1
+                          type: string
+                      required:
+                      - failed
+                      - success
+                      type: object
+                    title:
+                      description: title describes the task and is displayed as a
+                        step heading.
+                      minLength: 1
+                      type: string
+                  required:
+                  - description
+                  - title
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - description
+            - displayName
+            - durationMinutes
+            - introduction
+            - tasks
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/dashboard.opendatahub.io_odhapplications.yaml
+++ b/bundle/manifests/dashboard.opendatahub.io_odhapplications.yaml
@@ -1,0 +1,167 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  labels:
+    opendatahub.io/dashboardcrd: "true"
+  name: odhapplications.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: OdhApplication
+    listKind: OdhApplicationList
+    plural: odhapplications
+    singular: odhapplication
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OdhApplication is the Schema for the odhapplications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OdhApplicationSpec defines the desired state of OdhApplication
+            properties:
+              beta:
+                type: boolean
+              betaText:
+                type: string
+              betaTitle:
+                type: string
+              category:
+                type: string
+              comingSoon:
+                type: boolean
+              consoleLink:
+                type: string
+              csvName:
+                type: string
+              description:
+                type: string
+              displayName:
+                type: string
+              docsLink:
+                type: string
+              enable:
+                properties:
+                  actionLabel:
+                    type: string
+                  description:
+                    type: string
+                  link:
+                    type: string
+                  linkPreface:
+                    type: string
+                  title:
+                    type: string
+                  validationConfigMap:
+                    type: string
+                  validationJob:
+                    type: string
+                  validationSecret:
+                    type: string
+                  variableDisplayText:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  variableHelpText:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  variables:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              enableCR:
+                properties:
+                  field:
+                    type: string
+                  group:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  plural:
+                    type: string
+                  value:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              endpoint:
+                type: string
+              featureFlag:
+                type: string
+              getStartedLink:
+                type: string
+              getStartedMarkDown:
+                type: string
+              img:
+                type: string
+              internalRoute:
+                type: string
+              isEnabled:
+                type: boolean
+              kfdefApplications:
+                items:
+                  type: string
+                type: array
+              link:
+                type: string
+              provider:
+                type: string
+              quickStart:
+                type: string
+              route:
+                type: string
+              routeNamespace:
+                type: string
+              routeSuffix:
+                type: string
+              serviceName:
+                type: string
+              support:
+                type: string
+            required:
+            - description
+            - displayName
+            - docsLink
+            - getStartedLink
+            - getStartedMarkDown
+            - img
+            - provider
+            - support
+            type: object
+          status:
+            description: OdhApplicationStatus defines the observed state of OdhApplication
+            properties:
+              enabled:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/manifests/dashboard.opendatahub.io_odhdocuments.yaml
+++ b/bundle/manifests/dashboard.opendatahub.io_odhdocuments.yaml
@@ -1,0 +1,82 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  labels:
+    opendatahub.io/dashboardcrd: "true"
+  name: odhdocuments.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: OdhDocument
+    listKind: OdhDocumentList
+    plural: odhdocuments
+    singular: odhdocument
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: OdhDocument is the Schema for the odhdocuments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OdhDocumentSpec defines the desired state of OdhDocument
+            properties:
+              appName:
+                type: string
+              description:
+                type: string
+              displayName:
+                type: string
+              durationMinutes:
+                type: integer
+              featureFlag:
+                type: string
+              icon:
+                type: string
+              img:
+                type: string
+              provider:
+                type: string
+              type:
+                type: string
+              url:
+                type: string
+            required:
+            - description
+            - displayName
+            - durationMinutes
+            - type
+            - url
+            type: object
+          status:
+            description: OdhDocumentStatus defines the observed state of OdhDocument
+            properties:
+              enabled:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -245,3 +244,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -5,6 +5,21 @@ metadata:
     alm-examples: |-
       [
         {
+          "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
+          "kind": "DataScienceCluster",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "opendatahub-operator",
+              "app.kubernetes.io/instance": "datasciencecluster-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "datasciencecluster",
+              "app.kubernetes.io/part-of": "opendatahub-operator"
+            },
+            "name": "datasciencecluster-sample"
+          },
+          "spec": null
+        },
+        {
           "apiVersion": "dscinitialization.opendatahub.io/v1alpha1",
           "kind": "DSCInitialization",
           "metadata": {
@@ -29,11 +44,28 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: DataScienceCluster is the Schema for the datascienceclusters API
+      displayName: Data Science Cluster
+      kind: DataScienceCluster
+      name: datascienceclusters.datasciencecluster.opendatahub.io
+      version: v1alpha1
     - description: DSCInitialization is the Schema for the dscinitializations API
       displayName: DSC Initialization
       kind: DSCInitialization
       name: dscinitializations.dscinitialization.opendatahub.io
       version: v1alpha1
+    - kind: OdhApplication
+      name: odhapplications.dashboard.opendatahub.io
+      version: v1
+    - kind: OdhDashboardConfig
+      name: odhdashboardconfigs.opendatahub.io
+      version: v1alpha
+    - kind: OdhDocument
+      name: odhdocuments.dashboard.opendatahub.io
+      version: v1
+    - kind: OdhQuickStart
+      name: odhquickstarts.console.openshift.io
+      version: v1
   description: Primary operator provided by ODH to enable Data Science components
   displayName: Open Data Hub Operator
   icon:
@@ -71,6 +103,32 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - datasciencecluster.opendatahub.io
+          resources:
+          - datascienceclusters
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - datasciencecluster.opendatahub.io
+          resources:
+          - datascienceclusters/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - datasciencecluster.opendatahub.io
+          resources:
+          - datascienceclusters/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - dscinitialization.opendatahub.io
           resources:
@@ -182,7 +240,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/vhire/opendatahub-operator:dev-0.0.1
+                image: registry.jharmison.com/library/opendatahub-operator:dev
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/opendatahub.io_odhdashboardconfigs.yaml
+++ b/bundle/manifests/opendatahub.io_odhdashboardconfigs.yaml
@@ -1,0 +1,172 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: odhdashboardconfigs.opendatahub.io
+spec:
+  group: opendatahub.io
+  names:
+    kind: OdhDashboardConfig
+    plural: odhdashboardconfigs
+    singular: odhdashboardconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              dashboardConfig:
+                properties:
+                  disableBYONImageStream:
+                    type: boolean
+                  disableClusterManager:
+                    type: boolean
+                  disableCustomServingRuntimes:
+                    type: boolean
+                  disableISVBadges:
+                    type: boolean
+                  disableInfo:
+                    type: boolean
+                  disableModelServing:
+                    type: boolean
+                  disablePipelines:
+                    type: boolean
+                  disableProjectSharing:
+                    type: boolean
+                  disableProjects:
+                    type: boolean
+                  disableSupport:
+                    type: boolean
+                  disableTracking:
+                    type: boolean
+                  disableUserManagement:
+                    type: boolean
+                  enablement:
+                    type: boolean
+                  modelMetricsNamespace:
+                    type: string
+                type: object
+              groupsConfig:
+                properties:
+                  adminGroups:
+                    type: string
+                  allowedGroups:
+                    type: string
+                required:
+                - adminGroups
+                - allowedGroups
+                type: object
+              modelServerSizes:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    resources:
+                      properties:
+                        limits:
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                        requests:
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              notebookController:
+                properties:
+                  enabled:
+                    type: boolean
+                  gpuSetting:
+                    description: Configure how the GPU field works on the Jupyter
+                      tile. One of 'autodetect' (default, fetches for information),
+                      'hidden' (remove the field) or a number-string (eg '5') to specify
+                      a hardcoded 0 to that number options
+                    type: string
+                  notebookNamespace:
+                    type: string
+                  notebookTolerationSettings:
+                    properties:
+                      enabled:
+                        type: boolean
+                      key:
+                        type: string
+                    type: object
+                  pvcSize:
+                    type: string
+                  storageClassName:
+                    type: string
+                required:
+                - enabled
+                type: object
+              notebookSizes:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    resources:
+                      properties:
+                        limits:
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                        requests:
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - resources
+                  type: object
+                type: array
+              templateOrder:
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            properties:
+              notebookControllerState:
+                items:
+                  properties:
+                    lastActivity:
+                      type: number
+                    lastSelectedImage:
+                      type: string
+                    lastSelectedSize:
+                      type: string
+                    user:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/odhapplications.dashboard.opendatahub.io_odhapplications.yaml
+++ b/config/crd/bases/odhapplications.dashboard.opendatahub.io_odhapplications.yaml
@@ -1,0 +1,168 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: odhapplications.dashboard.opendatahub.io
+  labels:
+    opendatahub.io/dashboardcrd: "true"
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: OdhApplication
+    listKind: OdhApplicationList
+    plural: odhapplications
+    singular: odhapplication
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OdhApplication is the Schema for the odhapplications
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OdhApplicationSpec defines the desired state of OdhApplication
+              properties:
+                beta:
+                  type: boolean
+                betaText:
+                  type: string
+                betaTitle:
+                  type: string
+                category:
+                  type: string
+                comingSoon:
+                  type: boolean
+                consoleLink:
+                  type: string
+                csvName:
+                  type: string
+                description:
+                  type: string
+                displayName:
+                  type: string
+                docsLink:
+                  type: string
+                enable:
+                  properties:
+                    actionLabel:
+                      type: string
+                    description:
+                      type: string
+                    link:
+                      type: string
+                    linkPreface:
+                      type: string
+                    title:
+                      type: string
+                    validationConfigMap:
+                      type: string
+                    validationJob:
+                      type: string
+                    validationSecret:
+                      type: string
+                    variableDisplayText:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    variableHelpText:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    variables:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                enableCR:
+                  properties:
+                    field:
+                      type: string
+                    group:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    plural:
+                      type: string
+                    value:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                endpoint:
+                  type: string
+                featureFlag:
+                  type: string
+                getStartedLink:
+                  type: string
+                getStartedMarkDown:
+                  type: string
+                img:
+                  type: string
+                isEnabled:
+                  type: boolean
+                kfdefApplications:
+                  items:
+                    type: string
+                  type: array
+                link:
+                  type: string
+                provider:
+                  type: string
+                quickStart:
+                  type: string
+                internalRoute:
+                  type: string
+                route:
+                  type: string
+                routeNamespace:
+                  type: string
+                routeSuffix:
+                  type: string
+                serviceName:
+                  type: string
+                support:
+                  type: string
+              required:
+                - description
+                - displayName
+                - docsLink
+                - getStartedLink
+                - getStartedMarkDown
+                - img
+                - provider
+                - support
+              type: object
+            status:
+              description: OdhApplicationStatus defines the observed state of OdhApplication
+              properties:
+                enabled:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/odhdashboardconfigs.opendatahub.io_odhdashboardconfigs.yaml
+++ b/config/crd/bases/odhdashboardconfigs.opendatahub.io_odhdashboardconfigs.yaml
@@ -1,0 +1,162 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: odhdashboardconfigs.opendatahub.io
+spec:
+  group: opendatahub.io
+  scope: Namespaced
+  names:
+    plural: odhdashboardconfigs
+    singular: odhdashboardconfig
+    kind: OdhDashboardConfig
+  versions:
+    - name: v1alpha
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              properties:
+                dashboardConfig:
+                  type: object
+                  properties:
+                    enablement:
+                      type: boolean
+                    disableInfo:
+                      type: boolean
+                    disableSupport:
+                      type: boolean
+                    disableClusterManager:
+                      type: boolean
+                    disableTracking:
+                      type: boolean
+                    disableBYONImageStream:
+                      type: boolean
+                    disableISVBadges:
+                      type: boolean
+                    disableUserManagement:
+                      type: boolean
+                    disableProjects:
+                      type: boolean
+                    disableModelServing:
+                      type: boolean
+                    disableProjectSharing:
+                      type: boolean
+                    disableCustomServingRuntimes:
+                      type: boolean
+                    modelMetricsNamespace:
+                      type: string
+                    disablePipelines:
+                      type: boolean
+                groupsConfig:
+                  type: object
+                  required:
+                    - adminGroups
+                    - allowedGroups
+                  properties:
+                    adminGroups:
+                      type: string
+                    allowedGroups:
+                      type: string
+                notebookSizes:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - resources
+                    properties:
+                      name:
+                        type: string
+                      resources:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                modelServerSizes:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - resources
+                    properties:
+                      name:
+                        type: string
+                      resources:
+                        type: object
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                              memory:
+                                type: string
+                notebookController:
+                  type: object
+                  required:
+                    - enabled
+                  properties:
+                    enabled:
+                      type: boolean
+                    notebookNamespace:
+                      type: string
+                    pvcSize:
+                      type: string
+                    gpuSetting:
+                      description: Configure how the GPU field works on the Jupyter tile. One of 'autodetect' (default, fetches for information), 'hidden' (remove the field) or a number-string (eg '5') to specify a hardcoded 0 to that number options
+                      type: string
+                    notebookTolerationSettings:
+                      type: object
+                      properties:
+                          enabled:
+                            type: boolean
+                          key:
+                            type: string
+                    storageClassName:
+                      type: string
+                templateOrder:
+                  type: array
+                  items:
+                    type: string
+            status:
+              type: object
+              properties:
+                notebookControllerState:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      user:
+                        type: string
+                      lastSelectedImage:
+                        type: string
+                      lastSelectedSize:
+                        type: string
+                      lastActivity:
+                        type: number

--- a/config/crd/bases/odhdocuments.dashboard.opendatahub.io_odhdocuments.yaml
+++ b/config/crd/bases/odhdocuments.dashboard.opendatahub.io_odhdocuments.yaml
@@ -1,0 +1,83 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: odhdocuments.dashboard.opendatahub.io
+  labels:
+    opendatahub.io/dashboardcrd: "true"
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: OdhDocument
+    listKind: OdhDocumentList
+    plural: odhdocuments
+    singular: odhdocument
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OdhDocument is the Schema for the odhdocuments
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OdhDocumentSpec defines the desired state of OdhDocument
+              properties:
+                appName:
+                  type: string
+                description:
+                  type: string
+                displayName:
+                  type: string
+                durationMinutes:
+                  type: integer
+                featureFlag:
+                  type: string
+                icon:
+                  type: string
+                img:
+                  type: string
+                provider:
+                  type: string
+                type:
+                  type: string
+                url:
+                  type: string
+              required:
+                - description
+                - displayName
+                - durationMinutes
+                - type
+                - url
+              type: object
+            status:
+              description: OdhDocumentStatus defines the observed state of OdhDocument
+              properties:
+                enabled:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/odhquickstarts.console.openshift.io_odhquickstarts.yaml
+++ b/config/crd/bases/odhquickstarts.console.openshift.io_odhquickstarts.yaml
@@ -1,0 +1,208 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: odhquickstarts.console.openshift.io
+  labels:
+    opendatahub.io/dashboardcrd: "true"
+  annotations:
+    description: Extension for guiding user through various workflows in the Red Hat
+      OpenShift Data Science dashboard.
+    displayName: OdhQuickStart
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  scope: Namespaced
+  group: console.openshift.io
+  names:
+    plural: odhquickstarts
+    singular: odhquickstart
+    kind: OdhQuickStart
+    listKind: OdhQuickStartList
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: OdhQuickStart is an extension for guiding user through various
+            workflows in the Red Hat OpenShift Data Science dashboard.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OdhQuickStartSpec is the desired quick start configuration.
+              type: object
+              required:
+                - description
+                - displayName
+                - durationMinutes
+                - introduction
+                - tasks
+              properties:
+                accessReviewResources:
+                  description: accessReviewResources contains a list of resources that
+                    the user's access will be reviewed against in order for the user
+                    to complete the Quick Start. The Quick Start will be hidden if any
+                    of the access reviews fail.
+                  type: array
+                  items:
+                    description: ResourceAttributes includes the authorization attributes
+                      available for resource requests to the Authorizer interface
+                    type: object
+                    properties:
+                      group:
+                        description: Group is the API Group of the Resource.  "*" means
+                          all.
+                        type: string
+                      name:
+                        description: Name is the name of the resource being requested
+                          for a "get" or deleted for a "delete". "" (empty) means all.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the action being
+                          requested.  Currently, there is no distinction between no
+                          namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews
+                          "" (empty) is empty for cluster-scoped resources "" (empty)
+                          means "all" for namespace scoped resources from a SubjectAccessReview
+                          or SelfSubjectAccessReview
+                        type: string
+                      resource:
+                        description: Resource is one of the existing resource types.  "*"
+                          means all.
+                        type: string
+                      subresource:
+                        description: Subresource is one of the existing resource types.  ""
+                          means none.
+                        type: string
+                      verb:
+                        description: 'Verb is a kubernetes resource API verb, like:
+                        get, list, watch, create, update, delete, proxy.  "*" means
+                        all.'
+                        type: string
+                      version:
+                        description: Version is the API Version of the Resource.  "*"
+                          means all.
+                        type: string
+                appName:
+                  description: the name/id of the odh application the quick start pertains to
+                  type: string
+                conclusion:
+                  description: conclusion sums up the Quick Start and suggests the possible
+                    next steps. (includes markdown)
+                  type: string
+                description:
+                  description: description is the description of the Quick Start. (includes
+                    markdown)
+                  type: string
+                  maxLength: 256
+                  minLength: 1
+                displayName:
+                  description: displayName is the display name of the Quick Start.
+                  type: string
+                  minLength: 1
+                durationMinutes:
+                  description: durationMinutes describes approximately how many minutes
+                    it will take to complete the Quick Start.
+                  type: integer
+                  minimum: 1
+                icon:
+                  description: icon is a base64 encoded image that will be displayed
+                    beside the Quick Start display name. The icon should be an vector
+                    image for easy scaling. The size of the icon should be 40x40.
+                  type: string
+                introduction:
+                  description: introduction describes the purpose of the Quick Start.
+                    (includes markdown)
+                  type: string
+                  minLength: 1
+                nextQuickStart:
+                  description: nextQuickStart is a list of the following Quick Starts,
+                    suggested for the user to try.
+                  type: array
+                  items:
+                    type: string
+                prerequisites:
+                  description: prerequisites contains all prerequisites that need to
+                    be met before taking a Quick Start. (includes markdown)
+                  type: array
+                  items:
+                    type: string
+                tags:
+                  description: tags is a list of strings that describe the Quick Start.
+                  type: array
+                  items:
+                    type: string
+                tasks:
+                  description: tasks is the list of steps the user has to perform to
+                    complete the Quick Start.
+                  type: array
+                  minItems: 1
+                  items:
+                    description: OdhQuickStartTask is a single step in a Quick Start.
+                    type: object
+                    required:
+                      - description
+                      - title
+                    properties:
+                      description:
+                        description: description describes the steps needed to complete
+                          the task. (includes markdown)
+                        type: string
+                        minLength: 1
+                      review:
+                        description: review contains instructions to validate the task
+                          is complete. The user will select 'Yes' or 'No'. using a radio
+                          button, which indicates whether the step was completed successfully.
+                        type: object
+                        required:
+                          - failedTaskHelp
+                          - instructions
+                        properties:
+                          failedTaskHelp:
+                            description: failedTaskHelp contains suggestions for a failed
+                              task review and is shown at the end of task. (includes
+                              markdown)
+                            type: string
+                            minLength: 1
+                          instructions:
+                            description: instructions contains steps that user needs
+                              to take in order to validate his work after going through
+                              a task. (includes markdown)
+                            type: string
+                            minLength: 1
+                      summary:
+                        description: summary contains information about the passed step.
+                        type: object
+                        required:
+                          - failed
+                          - success
+                        properties:
+                          failed:
+                            description: failed briefly describes the unsuccessfully
+                              passed task. (includes markdown)
+                            type: string
+                            maxLength: 128
+                            minLength: 1
+                          success:
+                            description: success describes the succesfully passed task.
+                            type: string
+                            minLength: 1
+                      title:
+                        description: title describes the task and is displayed as a
+                          step heading.
+                        type: string
+                        minLength: 1

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,6 +4,10 @@
 resources:
 - bases/dscinitialization.opendatahub.io_dscinitializations.yaml
 - bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+- bases/odhapplications.dashboard.opendatahub.io_odhapplications.yaml
+- bases/odhdashboardconfigs.opendatahub.io_odhdashboardconfigs.yaml
+- bases/odhdocuments.dashboard.opendatahub.io_odhdocuments.yaml
+- bases/odhquickstarts.console.openshift.io_odhquickstarts.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/vhire/opendatahub-operator
-  newTag: dev-0.0.1
+  newName: registry.jharmison.com/library/opendatahub-operator
+  newTag: dev

--- a/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/opendatahub-operator.clusterserviceversion.yaml
@@ -10,6 +10,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: DataScienceCluster is the Schema for the datascienceclusters API
+      displayName: Data Science Cluster
+      kind: DataScienceCluster
+      name: datascienceclusters.datasciencecluster.opendatahub.io
+      version: v1alpha1
     - description: DSCInitialization is the Schema for the dscinitializations API
       displayName: DSC Initialization
       kind: DSCInitialization

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,9 +6,107 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'
   verbs:
   - '*'
-
+- apiGroups:
+  - addons.managed.openshift.io
+  resources:
+  - addons
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - datasciencecluster.opendatahub.io
+  resources:
+  - datascienceclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datasciencecluster.opendatahub.io
+  resources:
+  - datascienceclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - datasciencecluster.opendatahub.io
+  resources:
+  - datascienceclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - dscinitialization.opendatahub.io
+  resources:
+  - dscinitializations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dscinitialization.opendatahub.io
+  resources:
+  - dscinitializations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - dscinitialization.opendatahub.io
+  resources:
+  - dscinitializations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/toolbox.Dockerfile
+++ b/toolbox.Dockerfile
@@ -12,5 +12,5 @@ RUN curl -Lo /tmp/golang.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.t
  && echo -e '#!/bin/bash\nflatpak-spawn --host podman "${@}"' > /usr/local/bin/podman \
  && chmod +x /usr/local/bin/operator-sdk /usr/local/bin/podman \
  && echo -e 'GOROOT=/usr/local/go\nGOPATH=$HOME/go\nPATH=$GOPATH/bin:$GOROOT/bin:$PATH\nexport GOROOT GOPATH PATH' > /etc/profile.d/go.sh \
- && dnf -y install gcc make \
+ && dnf -y install gcc make ripgrep \
  && dnf -y clean all

--- a/toolbox.Dockerfile
+++ b/toolbox.Dockerfile
@@ -11,4 +11,6 @@ RUN curl -Lo /tmp/golang.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.t
  && curl -Lo /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 \
  && echo -e '#!/bin/bash\nflatpak-spawn --host podman "${@}"' > /usr/local/bin/podman \
  && chmod +x /usr/local/bin/operator-sdk /usr/local/bin/podman \
- && echo -e 'GOROOT=/usr/local/go\nGOPATH=$HOME/go\nPATH=$GOPATH/bin:$GOROOT/bin:$PATH\nexport GOROOT GOPATH PATH' > /etc/profile.d/go.sh
+ && echo -e 'GOROOT=/usr/local/go\nGOPATH=$HOME/go\nPATH=$GOPATH/bin:$GOROOT/bin:$PATH\nexport GOROOT GOPATH PATH' > /etc/profile.d/go.sh \
+ && dnf -y install gcc make \
+ && dnf -y clean all

--- a/toolbox.Dockerfile
+++ b/toolbox.Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.fedoraproject.org/fedora-toolbox:38
+
+ARG GOLANG_VERSION=1.18.9
+ARG OPERATOR_SDK_VERSION=1.24.1
+
+ENV GOLANG_VERSION=$GOLANG_VERSION \
+    OPERATOR_SDK_VERSION=$OPERATOR_SDK_VERSION
+
+RUN curl -Lo /tmp/golang.tgz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+ && tar xvzf /tmp/golang.tgz -C /usr/local \
+ && curl -Lo /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_linux_amd64 \
+ && echo -e '#!/bin/bash\nflatpak-spawn --host podman "${@}"' > /usr/local/bin/podman \
+ && chmod +x /usr/local/bin/operator-sdk /usr/local/bin/podman \
+ && echo -e 'GOROOT=/usr/local/go\nGOPATH=$HOME/go\nPATH=$GOPATH/bin:$GOROOT/bin:$PATH\nexport GOROOT GOPATH PATH' > /etc/profile.d/go.sh


### PR DESCRIPTION
- Add Dashboard CRDs from [odh-deployer](https://github.com/red-hat-data-services/odh-deployer/tree/main/odh-dashboard/crds)
- Depend on ODH manifest download for image build
- Fix for local manifests target syntax
- Add makefile target for local toolbox image to ensure correct versions of golang and operator-sdk